### PR TITLE
fix error for empty localStorage

### DIFF
--- a/src/context/watchListContext.js
+++ b/src/context/watchListContext.js
@@ -5,7 +5,7 @@ export const WatchListContext = createContext();
 export const WatchListContextProvider = (props) => {
   console.log();
   const [watchList, setWatchList] = useState(
-    localStorage.getItem("watchList").split(",") || [
+    localStorage.getItem("watchList")?.split(",") || [
       "bitcoin",
       "ethereum",
       "ripple",


### PR DESCRIPTION
when `localStorage `doesn't have `"watchlist"` we get tihs error:
`TypeError: Cannot read property 'split' of null`